### PR TITLE
FIX incorrect remark indent, numbering

### DIFF
--- a/af/08.md
+++ b/af/08.md
@@ -109,7 +109,7 @@ style: chapter
 
 ## 170. Ander howe
 
-1.	Alle howe buiten dié in artikels 167, 168 en 169 bedoel kan enige aangeleentheid beslis wat deur ŉ Parlementswet bepaal word, maar ŉ hof met ŉ laer status as die Hooggeregshof van Suid-Afrika mag nie ondersoek instel na of beslis oor die grondwetlikheid van enige wetgewing of enige optrede van die President nie.
+Alle howe buiten dié in artikels 167, 168 en 169 bedoel kan enige aangeleentheid beslis wat deur ŉ Parlementswet bepaal word, maar ŉ hof met ŉ laer status as die Hooggeregshof van Suid-Afrika mag nie ondersoek instel na of beslis oor die grondwetlikheid van enige wetgewing of enige optrede van die President nie.
 
 > [A. 170 vervang by a. 6 van die Sewentiende Wysigingswet op die Grondwet van 2012.]
 {:.note}

--- a/en/08.md
+++ b/en/08.md
@@ -111,8 +111,8 @@ title: 8. Courts and Administration of Justice
 
 All courts other than those referred to in sections 167, 168 and 169 may decide any matter determined by an Act of Parliament, but a court of a status lower than the High Court of South Africa may not enquire into or rule on the constitutionality of any legislation or any conduct of the President.
 
-	> [S. 170 substituted by s. 6 of the Constitution Seventeenth Amendment Act of 2012.]
-	{:.note}
+> [S. 170 substituted by s. 6 of the Constitution Seventeenth Amendment Act of 2012.]
+{:.note}
 
 
 ## 171. Court procedures

--- a/xh/08.md
+++ b/xh/08.md
@@ -109,14 +109,14 @@ style: chapter
 
 ## 170. Ezinye iinkundla
 
-1.	Zonke iinkundla ngaphandle kwezo kuthethwe ngazo kwisiqendu 167, 168 nesama-169 zinokwenz’isigqibo ngawo nawuphi na umcimbi ogqitywe nguMthetho wePalamente, kodwa inkundla ekwinqanaba elingaphantsi kweleNkundla Ephakamileyo YoMzantsi- Afrika ayivumelekanga ukuba izame ukufumana ukuba uyavisisana kusini na noMgaqo- siseko umthetho wepalamente okanye isenzo sikaMongameli okanye yenze isigqibo ngako oko.
+Zonke iinkundla ngaphandle kwezo kuthethwe ngazo kwisiqendu 167, 168 nesama-169 zinokwenz’isigqibo ngawo nawuphi na umcimbi ogqitywe nguMthetho wePalamente, kodwa inkundla ekwinqanaba elingaphantsi kweleNkundla Ephakamileyo YoMzantsi- Afrika ayivumelekanga ukuba izame ukufumana ukuba uyavisisana kusini na noMgaqo- siseko umthetho wepalamente okanye isenzo sikaMongameli okanye yenze isigqibo ngako oko.
 
 > [Isiqendu 170 sithatyathelwe indawo sisiqendu 6 soMthetho Weshumi Elinesixhenxe Wokwenz’ Utshintsho KuMgaqo-siseko ka-2012]
 {:.note}
 
 ## 171. Iinkqubo zeenkundla
 
-1.	Zonke iinkundla zisebenza ngokomthetho wepalamente wezwelonke, kananjalo imigaqo yazo neenkqubo mazixelwe ngumthetho wepalamente wezwelonke.
+Zonke iinkundla zisebenza ngokomthetho wepalamente wezwelonke, kananjalo imigaqo yazo neenkqubo mazixelwe ngumthetho wepalamente wezwelonke.
 
 ## 172. Amagunya eenkundla kwimicimbi engoMgaqo-siseko
 

--- a/zu/08.md
+++ b/zu/08.md
@@ -164,9 +164,9 @@ style: chapter
 ## 170. Ezinye izinkantolo
 
 Zonke izinkantolo ngaphandle kwalezo ezivezwe esigabeni 167, 168, 169 zinganquma nganoma iluphi udaba olushiwo nguMthetho Wephalamende, kodwa izinkantolo ezisezingeni elingaphansi kweleNkantolo ePhakeme yaseNingizimu Afrika azivunyelwe ukucwaninga noma zibeke isinqumo ngokuhambisana nomthethosisekelo kwanoma yimuphi umthetho noma isenzo sikaMongameli.
->
-	> [Isigaba 170 siguqulwe ngesigaba sesi 6 soMthetho wesikhombisa oChibiyela uMthethosisekelo wezi 2012.]
-	{:.note}
+
+> [Isigaba 170 siguqulwe ngesigaba sesi 6 soMthetho wesikhombisa oChibiyela uMthethosisekelo wezi 2012.]
+{:.note}
 
 ## 171. Izinqubo ezilandelwa yinkantolo
 


### PR DESCRIPTION
An indented > block renders as a code block if the preceeding block isn't a list.
Remove unnecessary numbering